### PR TITLE
Question3-2

### DIFF
--- a/intern_2week_study.xcodeproj/project.pbxproj
+++ b/intern_2week_study.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		0F35803C24EE4F2A003626F2 /* R.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 082CF76224D59281001F7680 /* R.generated.swift */; };
 		0F35803F24EE7C20003626F2 /* ArticleListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F35803E24EE7C20003626F2 /* ArticleListViewController.swift */; };
 		0F35804124EE7C3B003626F2 /* ArticleList.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0F35804024EE7C3B003626F2 /* ArticleList.storyboard */; };
+		0F35804424EE8143003626F2 /* IBDesignableButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F35804324EE8143003626F2 /* IBDesignableButton.swift */; };
 		0F49694C24EAB2600042477E /* Search.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08C9DD8E24E0162200459724 /* Search.storyboard */; };
 /* End PBXBuildFile section */
 
@@ -81,6 +82,7 @@
 		0F192CBF24E7C68500922FA5 /* ArticleListCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ArticleListCell.xib; sourceTree = "<group>"; };
 		0F35803E24EE7C20003626F2 /* ArticleListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleListViewController.swift; sourceTree = "<group>"; };
 		0F35804024EE7C3B003626F2 /* ArticleList.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ArticleList.storyboard; sourceTree = "<group>"; };
+		0F35804324EE8143003626F2 /* IBDesignableButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IBDesignableButton.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -256,6 +258,7 @@
 		08C9DD8C24E013FB00459724 /* Question3 */ = {
 			isa = PBXGroup;
 			children = (
+				0F35804224EE80E5003626F2 /* IBDesignableSettings */,
 				0F49693724EA3DB20042477E /* components */,
 				0F49693524EA3CBE0042477E /* screens */,
 			);
@@ -269,6 +272,14 @@
 				082CF76624D5A816001F7680 /* AriticleList */,
 			);
 			path = Question3Sample;
+			sourceTree = "<group>";
+		};
+		0F35804224EE80E5003626F2 /* IBDesignableSettings */ = {
+			isa = PBXGroup;
+			children = (
+				0F35804324EE8143003626F2 /* IBDesignableButton.swift */,
+			);
+			path = IBDesignableSettings;
 			sourceTree = "<group>";
 		};
 		0F49693524EA3CBE0042477E /* screens */ = {
@@ -440,6 +451,7 @@
 				0848136024DD7AA600BF590E /* QuestionListViewController.swift in Sources */,
 				0F35803F24EE7C20003626F2 /* ArticleListViewController.swift in Sources */,
 				0841933724D9505800BFCBD3 /* Logger.swift in Sources */,
+				0F35804424EE8143003626F2 /* IBDesignableButton.swift in Sources */,
 				088E557A24D669AF00A2FE3E /* Array+Extensions.swift in Sources */,
 				0F192CC024E7C68500922FA5 /* ArticleListCell.swift in Sources */,
 				0F35803C24EE4F2A003626F2 /* R.generated.swift in Sources */,

--- a/intern_2week_study/Question/Question3/IBDesignableSettings/IBDesignableButton.swift
+++ b/intern_2week_study/Question/Question3/IBDesignableSettings/IBDesignableButton.swift
@@ -1,0 +1,15 @@
+import UIKit
+
+@IBDesignable class IBDesignableButton: UIButton {
+
+    @IBInspectable var borderColor: UIColor = .clear
+    @IBInspectable var borderWidth: CGFloat = 0
+    @IBInspectable var cornerRadius: CGFloat = 0
+    
+    override func draw(_ rect: CGRect) {
+        self.layer.borderColor = borderColor.cgColor
+        self.layer.borderWidth = borderWidth
+        self.layer.cornerRadius = cornerRadius
+    }
+
+}

--- a/intern_2week_study/Question/Question3/screens/Search.storyboard
+++ b/intern_2week_study/Question/Question3/screens/Search.storyboard
@@ -16,10 +16,25 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4Fc-b5-6Xi">
-                                <rect key="frame" x="192" y="433.5" width="30" height="29"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4Fc-b5-6Xi" customClass="IBDesignableButton" customModule="intern_2week_study" customModuleProvider="target">
+                                <rect key="frame" x="107" y="433.5" width="200" height="29"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="200" id="0Dp-h3-cfs"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <color key="tintColor" red="0.33310675620000002" green="0.77347451450000004" blue="0.007701280992" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <state key="normal" title="検索"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                        <real key="value" value="1"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                        <color key="value" red="0.33310675620000002" green="0.77347451450000004" blue="0.007701280992" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                        <real key="value" value="6"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
                                 <connections>
                                     <action selector="searchArticles:" destination="hE7-Bk-rHS" eventType="touchDown" id="20O-78-yRv"/>
                                 </connections>


### PR DESCRIPTION
課題
---
[[課題3-2][UI]検索ボタンをリッチにする](https://github.com/Caraquri/intern_2week_study_ios/issues/4)

概要
---
テキストのみであった検索ボタンに角丸の枠線を付けた．

特に確認して頂きたい項目
---
- スタイリングの方法について検索すると，ソースコードに直接スタイルを記述する方法がQiitaやYoutubeでヒットするのですが，コードに直接記述する方法と，storyboard上で設定する方法ではどちらがメジャーなのでしょうか？ 個人的には，せっかくstoryboardがあるのにViewに関する情報をControllerに記述するのを躊躇ったので，IBDesignableに関するクラスを新規で作成し，storyboard側で枠線の色や太さを調整できるようにしました．
![スクリーンショット 2020-08-20 19 14 23](https://user-images.githubusercontent.com/64292043/90758064-649e3980-e319-11ea-8de8-5eff904f4145.png)

動作確認用 Screenshots
---
![スクリーンショット 2020-08-20 19 12 44](https://user-images.githubusercontent.com/64292043/90757896-2a349c80-e319-11ea-958f-ec1d47b840bf.png)

参考URL
---
- [@IBDesignable使ってXcodeのAttributes Inspectorで設定を変更，リアルタイムでデザインを確認できるUIButtonを作る](https://qiita.com/MilanistaDev/items/ba85a0bc557681b8041e)
